### PR TITLE
荷造りタスクをテンプレートから作成できるようにしました

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -10,7 +10,14 @@ class TasksController < ApplicationController
   end
 
   def create
-    @task = @travel_plan.tasks.build(task_params)
+    if params[:task][:template_id].present?
+      template_task = Task.find(params[:task][:template_id])
+      @task = template_task.dup
+      @task.assign_attributes(task_params)
+    else
+      @task = @travel_plan.tasks.build(task_params)
+    end
+  
     @task.user = current_user
     if @task.save
       redirect_to travel_plan_tasks_path(@travel_plan), success: t('tasks.create.success')

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -1,0 +1,17 @@
+class TemplatesController < ApplicationController
+  def index
+    @templates = TravelPlan.where(is_template: true)
+  end
+
+  def show
+    @template = TravelPlan.find(params[:id])
+    @travel_plan = @template # または適切なアソシエーションの設定
+    @q = Task.ransack(params[:q]) # 例: 検索クエリの設定
+  end
+
+  def create_travel_plan
+    template = TravelPlan.find(params[:id])
+    new_plan = TravelPlan.create_from_template(template.id)
+    redirect_to edit_travel_plan_path(new_plan), notice: "テンプレートから旅行プランを作成しました"
+  end
+end

--- a/app/controllers/travel_plans_controller.rb
+++ b/app/controllers/travel_plans_controller.rb
@@ -5,14 +5,23 @@ class TravelPlansController < ApplicationController
 
   def new
     @travel_plan = TravelPlan.new
+    if params[:template_id]
+      @template = TravelPlan.find(params[:template_id])
+    end
   end
+  
 
   def create
-    @travel_plan = current_user.travel_plans.build(travel_plan_params)
+    @travel_plan = TravelPlan.new(travel_plan_params)
     if @travel_plan.save
-      redirect_to travel_plans_path, success: t('travel_plans.create.success')
+      if params[:template_id]
+        template = TravelPlan.find(params[:template_id])
+        template.tasks.each do |task|
+          @travel_plan.tasks.create(task.attributes.except("id", "created_at", "updated_at"))
+        end
+      end
+      redirect_to travel_plan_tasks_path(@travel_plan), success: t('travel_plans.create.success')
     else
-      flash.now[:danger] = t('travel_plans.create.failure')
       render :new, status: :unprocessable_entity
     end
   end
@@ -36,6 +45,8 @@ class TravelPlansController < ApplicationController
     travel_plan.destroy!
     redirect_to travel_plans_path, success: t('travel_plans.destroy.success')
   end
+
+  def choose_template_or_create; end
 
   private
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -12,4 +12,6 @@ class Task < ApplicationRecord
   def self.ransackable_attributes(auth_object = nil)
     ["baggage", "body", "created_at", "due", "id", "status", "title", "travel_plan_id", "updated_at", "user_id"]
   end
+
+  scope :templates, -> { where(is_template: true) }
 end

--- a/app/models/travel_plan.rb
+++ b/app/models/travel_plan.rb
@@ -3,4 +3,32 @@ class TravelPlan < ApplicationRecord
   has_many :tasks, dependent: :destroy
 
   validates :title, presence: true
+
+  has_many :tasks
+
+  def self.create_from_template(template_id)
+    template = find(template_id)
+
+    # 新しいtravel_planをテンプレートから作成
+    new_plan = create(
+      title: "#{template.title}のコピー",
+      user_id: template.user_id, # 必要であればユーザーを設定
+      is_template: false # テンプレートではなく通常のプランとして作成
+    )
+
+    # テンプレートのtasksをコピー
+    template.tasks.each do |task|
+      new_plan.tasks.create(
+        title: task.title,
+        body: task.body,
+        due: task.due,
+        status: task.status,
+        baggage: task.baggage,
+        user_id: task.user_id, # 必要であればユーザーを設定
+        is_template: false
+      )
+    end
+
+    new_plan
+  end 
 end

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -12,7 +12,5 @@
         <%= link_to t('header.login'), login_path, class: "nav-link" %>
       </a>
     </nav>
-    <button class="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0">プロフィール
-    </button>
   </div>
 </header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,7 +9,7 @@
       </span>
     </a>
     <nav class="md:ml-auto md:mr-auto flex flex-wrap items-center text-base justify-center">
-      <%= link_to t('header.create_travel_plan'), new_travel_plan_path, class: "mr-5 hover:text-gray-900" %>
+      <%= link_to t('header.create_travel_plan'), '/choose_template_or_create', class: "mr-5 hover:text-gray-900" %>
       <%= link_to t('header.travel_plan_index'), travel_plans_path, class: "mr-5 hover:text-gray-900" %>
       <a class="mr-5 hover:text-gray-900"><%= t('header.tip') %></a>
       <a class="mr-5 hover:text-gray-900"><%= t('header.how_to_use') %></a>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -7,7 +7,7 @@
       <p class="mb-8 mx-auto leading-relaxed">何を持ち込んではいけないのか。調べ準備するだけでもかなり大変です。</p>
       <p class="mb-8 mx-auto leading-relaxed">Packing Checkerにぜひお手伝いさせてください。</p>
       <div class="mx-auto">
-        <%= link_to "荷造りをする", new_travel_plan_path, class: "ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg" %>
+        <%= link_to t('header.create_travel_plan'), '/choose_template_or_create', class: "ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg" %>
       </div>
     </div>
     <div class="lg:max-w-lg lg:w-full md:w-1/2 w-5/6">

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -3,9 +3,6 @@
   <div class="p-2 w-full">
     <div class="relative">
       <div class="mb-3">
-        <%= f.collection_select :template_id, Task.templates, :id, :title, include_blank: 'テンプレートから選択' %>
-      </div>
-      <div class="mb-3">
         <%= f.label :title, t('activerecord.attributes.task.title') %>
         <%= f.text_field :title, class: "w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" %>
       </div>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -3,6 +3,9 @@
   <div class="p-2 w-full">
     <div class="relative">
       <div class="mb-3">
+        <%= f.collection_select :template_id, Task.templates, :id, :title, include_blank: 'テンプレートから選択' %>
+      </div>
+      <div class="mb-3">
         <%= f.label :title, t('activerecord.attributes.task.title') %>
         <%= f.text_field :title, class: "w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" %>
       </div>

--- a/app/views/templates/index.html.erb
+++ b/app/views/templates/index.html.erb
@@ -1,0 +1,26 @@
+<section class="text-gray-600 body-font">
+  <div class="container px-5 py-24 mx-auto">
+    <div class="flex flex-col text-center w-full mb-20">
+      <h2 class="text-xs text-indigo-500 tracking-widest font-medium title-font mb-1">荷造りのテンプレート</h2>
+      <h1 class="sm:text-3xl text-2xl font-medium title-font text-gray-900">テンプレートたち</h1>
+    </div>
+    <div class="flex flex-wrap -m-4">
+      <% @templates.each do |template| %>
+        <div class="p-4 md:w-1/3">
+          <div class="flex rounded-lg h-full bg-gray-100 p-8 flex-col">
+            <div class="flex items-center mb-3">
+              <span class="text-gray-900 text-lg title-font font-medium px-8">
+                <%= link_to template.title, template_path(template) %>
+              </span>
+            </div>
+            <div class="flex-grow">
+              <p class="leading-relaxed text-base">
+                <%= template.note.presence || '&nbsp;'.html_safe %>
+              </p>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</section>

--- a/app/views/templates/show.html.erb
+++ b/app/views/templates/show.html.erb
@@ -1,0 +1,34 @@
+<section class="text-gray-600 body-font">
+  <div class="container px-5 py-24 mx-auto">
+    <div class="flex flex-col text-center w-full mb-20">
+      <h1 class="sm:text-4xl text-3xl font-medium title-font mb-2 text-gray-900"><%= @template.title %></h1>
+      <p class="lg:w-2/3 mx-auto leading-relaxed text-base"><%= @template.note %></p>
+    </div>
+    <div class="lg:w-2/3 w-full mx-auto overflow-auto">
+      <%= render 'shared/search_form' %>
+      <table class="table-auto w-full text-left whitespace-no-wrap ">
+        <thead>
+          <tr>
+            <th class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100 rounded-tl rounded-bl"><%= t('activerecord.attributes.task.title') %></th>
+            <th class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100"><%= t('activerecord.attributes.task.body') %></th>
+            <th class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100"><%= t('activerecord.attributes.task.baggage_type') %></th>
+            <th class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100"><%= t('helpers.submit.edit') %></th>
+            <th class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100"><%= t('helpers.submit.delete') %></th>
+            <th class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100 rounded-tr rounded-br"><%= t('activerecord.attributes.task.status_type') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @template.tasks.each do |task| %>
+            <tr>
+              <td class="px-4 py-3"><%= task.title %></td>
+              <td class="px-4 py-3"><%= task.body %></td>
+              <td class="px-4 py-3"><%= t("activerecord.attributes.task.baggage.#{task.baggage}") %></td>
+              <td class="px-4 py-3"><%= t("activerecord.attributes.task.status.#{task.status}") %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <%= button_to 'このテンプレートで準備をする', create_travel_plan_template_path(@template), method: :post %>
+    </div>
+  </div>
+</section>

--- a/app/views/travel_plans/choose_template_or_create.erb
+++ b/app/views/travel_plans/choose_template_or_create.erb
@@ -1,0 +1,26 @@
+<section class="text-gray-600 body-font">
+  <div class="container px-5 py-24 mx-auto">
+    <div class="flex flex-wrap md:flex-nowrap -mx-4 -mb-10 text-center">
+      <div class="md:w-1/2 w-full mb-10 px-4">
+        <div class="rounded-lg h-64 overflow-hidden">
+          <img alt="content" class="object-cover object-center h-full w-full" src="https://dummyimage.com/1201x501">
+        </div>
+        <h2 class="title-font text-2xl font-medium text-gray-900 mt-6 mb-3">Buy YouTube Videos</h2>
+        <p class="leading-relaxed text-base">Williamsburg occupy sustainable snackwave gochujang. Pinterest cornhole brunch, slow-carb neutra irony.</p>
+        <button class="flex mx-auto mt-6 text-white bg-indigo-500 border-0 py-2 px-5 focus:outline-none hover:bg-indigo-600 rounded">
+        <%= link_to 'テンプレートから作成', templates_path(redirect_to: new_travel_plan_path) %>
+      </button>
+      </div>
+      <div class="md:w-1/2 w-full mb-10 px-4">
+        <div class="rounded-lg h-64 overflow-hidden">
+          <img alt="content" class="object-cover object-center h-full w-full" src="https://dummyimage.com/1202x502">
+        </div>
+        <h2 class="title-font text-2xl font-medium text-gray-900 mt-6 mb-3">The Catalyzer</h2>
+        <p class="leading-relaxed text-base">Williamsburg occupy sustainable snackwave gochujang. Pinterest cornhole brunch, slow-carb neutra irony.</p>
+        <button class="flex mx-auto mt-6 text-white bg-indigo-500 border-0 py-2 px-5 focus:outline-none hover:bg-indigo-600 rounded">
+          <%= link_to '一から作成', new_travel_plan_path %>
+        </button>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/travel_plans/new.html.erb
+++ b/app/views/travel_plans/new.html.erb
@@ -3,9 +3,6 @@ zz<section class="text-gray-600 body-font">
     <div class="flex flex-col text-center w-full mb-12">
       <h1 class="title-font sm:text-4xl text-3xl mb-12 font-medium text-gray-900">
         <%= t('.subject') %>
-        <% if @template %>
-          <p>テンプレート「<%= @template.title %>」が選択されています。</p>
-        <% end %>
       </h1>
       <div class="lg:w-1/2 md:w-2/3 mx-auto">
         <div class="flex-wrap -m-2">

--- a/app/views/travel_plans/new.html.erb
+++ b/app/views/travel_plans/new.html.erb
@@ -1,8 +1,11 @@
-<section class="text-gray-600 body-font">
+zz<section class="text-gray-600 body-font">
   <div class="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
     <div class="flex flex-col text-center w-full mb-12">
       <h1 class="title-font sm:text-4xl text-3xl mb-12 font-medium text-gray-900">
         <%= t('.subject') %>
+        <% if @template %>
+          <p>テンプレート「<%= @template.title %>」が選択されています。</p>
+        <% end %>
       </h1>
       <div class="lg:w-1/2 md:w-2/3 mx-auto">
         <div class="flex-wrap -m-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,9 +14,16 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
-  delete 'logout', to: 'user_sessions#destroy'
+  delete 'logout', to: 'user_sessions#destroy' 
+  get "/choose_template_or_create", to: "travel_plans#choose_template_or_create"
 
-  resources :travel_plans, only: %i[index new create show edit destroy update] do
+  resources :templates, only: [:index, :show] do
+    member do
+      post :create_travel_plan
+    end
+  end  
+
+  resources :travel_plans, only: %i[index new create show edit destroy update choose_template_or_create] do
     resources :tasks
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
     end
   end  
 
-  resources :travel_plans, only: %i[index new create show edit destroy update choose_template_or_create] do
+  resources :travel_plans, only: %i[index new create show edit destroy update] do
     resources :tasks
   end
 

--- a/db/migrate/20240815054542_add_is_template_to_tasks.rb
+++ b/db/migrate/20240815054542_add_is_template_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddIsTemplateToTasks < ActiveRecord::Migration[7.2]
+  def change
+    add_column :tasks, :is_template, :boolean
+  end
+end

--- a/db/migrate/20240823011046_add_template_to_travel_plans.rb
+++ b/db/migrate/20240823011046_add_template_to_travel_plans.rb
@@ -1,0 +1,5 @@
+class AddTemplateToTravelPlans < ActiveRecord::Migration[7.2]
+  def change
+    add_column :travel_plans, :is_template, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_14_132057) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_15_054542) do
   create_table "tasks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title", null: false
     t.text "body"
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_14_132057) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "travel_plan_id"
+    t.boolean "is_template"
     t.index ["travel_plan_id"], name: "index_tasks_on_travel_plan_id"
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_15_054542) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_23_011046) do
   create_table "tasks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title", null: false
     t.text "body"
@@ -35,6 +35,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_15_054542) do
     t.bigint "task_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_template", default: false, null: false
     t.index ["task_id"], name: "index_travel_plans_on_task_id"
     t.index ["user_id"], name: "index_travel_plans_on_user_id"
   end


### PR DESCRIPTION
荷造りタスクをテンプレートから作成できるようにしました

概要ー導線ー
ヘッダーまたはトップページの「旅行計画を立てる」より、
「テンプレートから作成するか一から自分で作成するか」を選択する画面に移動。
「テンプレートから作成」を選ぶと、テンプレート(トラベルプラン)一覧画面に遷移。
任意のテンプレートタイトルを押すことで、詳細画面(荷造りタスク)に移行。
詳細画面の「このテンプレートで作成する」を押すことで自身のトラベルプランにコピーされ編集が可能になる。

構想
自分がすでに終わらせた荷造りをテンプレートに追加する機能を実装したい。